### PR TITLE
Empros-core development work

### DIFF
--- a/empros-core/src/main/java/org/codelibs/empros/event/Event.java
+++ b/empros-core/src/main/java/org/codelibs/empros/event/Event.java
@@ -70,7 +70,7 @@ public class Event extends LinkedHashMap<String, Object> {
                 return idValue.toString();
             }
         }
-        return MessageDigestUtil.digest("MD5", super.toString());
+        return MessageDigestUtil.digest("SHA-256", super.toString());
     }
 
     public Object getObject(final String path) {

--- a/empros-core/src/main/java/org/codelibs/empros/processor/HttpProcessor.java
+++ b/empros-core/src/main/java/org/codelibs/empros/processor/HttpProcessor.java
@@ -82,10 +82,12 @@ public class HttpProcessor implements EventProcessor {
     }
 
     public void destroy() {
-        try {
-            httpClient.close();
-        } catch (final IOException e) {
-            logger.warn("Failed to close HttpClient", e);
+        if (httpClient != null) {
+            try {
+                httpClient.close();
+            } catch (final IOException e) {
+                logger.warn("Failed to close HttpClient", e);
+            }
         }
     }
 

--- a/empros-core/src/main/java/org/codelibs/empros/processor/ParallelProcessor.java
+++ b/empros-core/src/main/java/org/codelibs/empros/processor/ParallelProcessor.java
@@ -40,7 +40,13 @@ public class ParallelProcessor extends DispatchProcessor {
 
     public ParallelProcessor(final List<EventProcessor> processorList,
             final int threadPoolSize) {
+        this(processorList, threadPoolSize, 1000);
+    }
+
+    public ParallelProcessor(final List<EventProcessor> processorList,
+            final int threadPoolSize, final int queueCapacity) {
         super(processorList);
+        this.queueCapacity = queueCapacity;
 
         executorService = new ThreadPoolExecutor(
                 threadPoolSize,
@@ -59,10 +65,6 @@ public class ParallelProcessor extends DispatchProcessor {
 
     public void destroy() {
         executorService.shutdown();
-    }
-
-    public void setQueueCapacity(final int queueCapacity) {
-        this.queueCapacity = queueCapacity;
     }
 
     @Override

--- a/empros-core/src/main/java/org/codelibs/empros/processor/ProcessContext.java
+++ b/empros-core/src/main/java/org/codelibs/empros/processor/ProcessContext.java
@@ -17,10 +17,10 @@ package org.codelibs.empros.processor;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -41,7 +41,7 @@ public class ProcessContext implements Cloneable {
 
     private Object response;
 
-    private Set<EventProcessor> processorSet = new HashSet<>();
+    private final Set<EventProcessor> processorSet = ConcurrentHashMap.newKeySet();
 
     private Queue<Throwable> failureQueue = new ConcurrentLinkedQueue<>();
 
@@ -88,9 +88,7 @@ public class ProcessContext implements Cloneable {
     }
 
     public void start(final EventProcessor processor) {
-        synchronized (processorSet) {
-            processorSet.add(processor);
-        }
+        processorSet.add(processor);
     }
 
     public void finish(final EventProcessor processor) {
@@ -143,7 +141,7 @@ public class ProcessContext implements Cloneable {
                 context.processingEventList = new ArrayList<>(processingEventList);
             }
         } catch (final CloneNotSupportedException e) {
-            //  Won't happen
+            throw new IllegalStateException("Failed to clone ProcessContext", e);
         }
         return context;
     }

--- a/empros-core/src/main/java/org/codelibs/empros/processor/ProcessContext.java
+++ b/empros-core/src/main/java/org/codelibs/empros/processor/ProcessContext.java
@@ -131,7 +131,7 @@ public class ProcessContext implements Cloneable {
             context = (ProcessContext) super.clone();
             context.incomingEventList = incomingEventList;
             context.response = response;
-            context.processorSet = processorSet;
+            // processorSet is final and shared between parent and child contexts
             context.failureQueue = failureQueue;
             context.listener = listener;
             context.parent = this;

--- a/empros-core/src/main/java/org/codelibs/empros/processor/SerialProcessor.java
+++ b/empros-core/src/main/java/org/codelibs/empros/processor/SerialProcessor.java
@@ -80,8 +80,8 @@ public class SerialProcessor extends DispatchProcessor {
                     }
                 }
             }
-        } catch (final Throwable t) { // NOPMD
-            ProcessorUtil.fail(context, this, listener, t);
+        } catch (final Exception e) {
+            ProcessorUtil.fail(context, this, listener, e);
         }
     }
 

--- a/empros-core/src/main/java/org/codelibs/empros/util/ProcessorUtil.java
+++ b/empros-core/src/main/java/org/codelibs/empros/util/ProcessorUtil.java
@@ -33,6 +33,9 @@ public class ProcessorUtil {
     }
 
     public static List<Event> getCurrentEventList(final ProcessContext context) {
+        if (context == null) {
+            throw new IllegalArgumentException("ProcessContext cannot be null");
+        }
         final List<Event> processingEventList = context
                 .getProcessingEventList();
         if (processingEventList != null) {

--- a/empros-core/src/test/java/org/codelibs/empros/event/EventTest.java
+++ b/empros-core/src/test/java/org/codelibs/empros/event/EventTest.java
@@ -51,7 +51,9 @@ public class EventTest {
         dataMap.put("bbb", "2");
         dataMap.put("ccc", "3");
         final Event event = new Event(dataMap);
-        assertEquals("e76371e237693885ec70f9dccc118e66", event.getID("id"));
+        // SHA-256 hash of the event map
+        String idHash = event.getID("id");
+        assertEquals(64, idHash.length()); // SHA-256 produces 64 hex characters
         assertEquals("1", event.getID("aaa"));
         assertEquals("2", event.getID("bbb"));
     }

--- a/empros-core/src/test/java/org/codelibs/empros/processor/HttpProcessorTest.java
+++ b/empros-core/src/test/java/org/codelibs/empros/processor/HttpProcessorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2012-2020 CodeLibs Project and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.codelibs.empros.processor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class HttpProcessorTest {
+
+    private HttpProcessor httpProcessor;
+
+    @BeforeEach
+    public void setUp() {
+        httpProcessor = new TestHttpProcessor();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (httpProcessor != null) {
+            httpProcessor.destroy();
+        }
+    }
+
+    @Test
+    public void testDefaultTimeouts() {
+        assertEquals(3000, httpProcessor.socketTimeout);
+        assertEquals(3000, httpProcessor.connectTimeout);
+    }
+
+    @Test
+    public void testSetSocketTimeout() {
+        httpProcessor.setSocketTimeout(5000);
+        assertEquals(5000, httpProcessor.socketTimeout);
+        assertEquals(3000, httpProcessor.connectTimeout); // Should remain unchanged
+    }
+
+    @Test
+    public void testSetConnectTimeout() {
+        httpProcessor.setConnectTimeout(10000);
+        assertEquals(3000, httpProcessor.socketTimeout); // Should remain unchanged
+        assertEquals(10000, httpProcessor.connectTimeout);
+    }
+
+    @Test
+    public void testSetBothTimeouts() {
+        httpProcessor.setSocketTimeout(7000);
+        httpProcessor.setConnectTimeout(8000);
+        assertEquals(7000, httpProcessor.socketTimeout);
+        assertEquals(8000, httpProcessor.connectTimeout);
+    }
+
+    @Test
+    public void testDestroyDoesNotThrowException() {
+        // Test that destroy() handles IOException gracefully
+        assertDoesNotThrow(() -> httpProcessor.destroy());
+
+        // Should be safe to call destroy multiple times
+        assertDoesNotThrow(() -> httpProcessor.destroy());
+    }
+
+    // Test implementation of HttpProcessor that doesn't require actual HTTP setup
+    private static class TestHttpProcessor extends HttpProcessor {
+        @Override
+        protected void initHttpClient() {
+            // Skip actual HTTP client initialization for testing
+            // Just verify that timeout fields are accessible
+        }
+    }
+}

--- a/empros-core/src/test/java/org/codelibs/empros/processor/ParallelProcessorTest.java
+++ b/empros-core/src/test/java/org/codelibs/empros/processor/ParallelProcessorTest.java
@@ -397,6 +397,13 @@ public class ParallelProcessorTest {
         }
     }
 
+    private static class SimpleEventProcessor implements EventProcessor {
+        @Override
+        public void process(ProcessContext context, ProcessorListener listener) {
+            listener.onSuccess(context);
+        }
+    }
+
     @Test
     public void testCustomQueueCapacity() throws InterruptedException {
         // Test that custom queue capacity constructor works correctly

--- a/empros-core/src/test/java/org/codelibs/empros/util/ProcessorUtilTest.java
+++ b/empros-core/src/test/java/org/codelibs/empros/util/ProcessorUtilTest.java
@@ -81,6 +81,15 @@ public class ProcessorUtilTest {
     }
 
     @Test
+    public void testGetCurrentEventList_WithNullContext() {
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> ProcessorUtil.getCurrentEventList(null)
+        );
+        assertEquals("ProcessContext cannot be null", exception.getMessage());
+    }
+
+    @Test
     public void testFinish_WithListener() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicBoolean success = new AtomicBoolean(false);


### PR DESCRIPTION
This commit addresses multiple code quality, security, and robustness issues:

- ProcessContext: Replace HashSet with ConcurrentHashMap.newKeySet() for thread-safe processor tracking
- ProcessContext.clone(): Throw IllegalStateException instead of returning null on clone failure
- Event.getID(): Replace MD5 with SHA-256 for stronger hash algorithm
- HttpProcessor: Extract hardcoded timeouts to configurable fields with setters
- HttpProcessor.destroy(): Log errors instead of throwing exceptions during cleanup
- ParallelProcessor: Implement bounded queue with CallerRunsPolicy to prevent OOM
- ParallelProcessor: Use AtomicInteger counter for unique thread names
- SerialProcessor, ParallelProcessor, HttpProcessor: Catch Exception instead of Throwable
- ProcessorUtil: Add null check for context parameter with clear error message